### PR TITLE
add the test logbook TLOG as an option

### DIFF
--- a/RasterLogBookEntry.h
+++ b/RasterLogBookEntry.h
@@ -75,7 +75,7 @@ public:
    std::string fTitle;
    TGTextEntry* fTitleEntry;
    std::string fLogBooks{"HBLOG"};
-   std::vector<std::string> fLogBookChoices = {"HBLOG", "ELOG", "HBLOG,ELOG"};
+   std::vector<std::string> fLogBookChoices = {"HBLOG", "ELOG", "HBLOG,ELOG", "TLOG"};
    TGComboBox* fLogBookCBox;
    std::string fEntryMakers{""};
    TGTextEntry* fEntryMakersEntry;


### PR DESCRIPTION
Looks like we will have some JRE version compatibility issues with the "logentry" executable (but not our java stuff that use the logbook java library directly).  Adding TLOG as an option will assist fixing that, and is always a good idea anyway.