### PR TITLE
hardwire to Oracle 8 JRE for "logentry"

### DIFF
--- a/rastermon.sh
+++ b/rastermon.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
+
 # Setup and run the RasterMon code.
 export PATH=/home/clasrun/RasterMon/bin:/u/apps/gcc/9.3.0/bin:/u/apps/cmake/3.22.1/bin/:${PATH}
 export LD_LIBRARY_PATH=/home/clasrun/RasterMon/lib:/u/apps/gcc/9.3.0/lib64:/u/apps/gcc/9.3.0/lib:${LD_LIBRARY_PATH}
 export VIRTUAL_ENV_DISABLE_PROMPT="true"
 source /home/clasrun/Python3/bin/activate
 source /home/clasrun/RasterMon/root/bin/thisroot.sh 
+
+# The "logentry" executable from the accelerator apparently requires oracle 8:
+export JAVA_HOME=/usr/clas12/third-party-libs/jdk/1.8.0_31
+export PATH=${JAVA_HOME}/bin:${PATH}
 
 if [[ "$(basename -- "$0")" == "rastermon.sh" ]]; then
     /home/clasrun/RasterMon/bin/RasterMon $@


### PR DESCRIPTION
The accelerator's "logentry" executable is incompatible with modern JREs, and this is a workaround for that.

We switched clon machines to openjdk 11 a couple weeks ago, after thinking everything had been tested, but only realized recently that "logentry" is an outlier.  Since all our other online stuff is either (1) java and so uses the accelerator's jlog Java library directly (which indeed works with modern JREs), or (2) spawns "logentry" from a process that already requires Oracle 8 (e.g. cs-studio), this issue wasn't noticed.

Not nice, but since there's already clon-specific stuff in this rastermon setup script, and it also already has requirements that are incompatible with the standard clon environment (for good reasons), no big harm, and better to put it here than further clutter clasrun's .cshrc.